### PR TITLE
Preliminary EventReplicationDecider

### DIFF
--- a/src/main/scala/com/rbmhtechnology/eventuate/sandbox/Event.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/sandbox/Event.scala
@@ -34,3 +34,5 @@ case class EncodedEvent(metadata: EventMetadata, payload: EventBytes) extends Du
       localSequenceNr = localSequenceNr))
   }
 }
+
+case class FullEvent(encoded: EncodedEvent, decoded: DecodedEvent)

--- a/src/main/scala/com/rbmhtechnology/eventuate/sandbox/EventCompatibility.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/sandbox/EventCompatibility.scala
@@ -3,27 +3,31 @@ package com.rbmhtechnology.eventuate.sandbox
 import akka.serialization.Serialization
 import akka.serialization.Serializer
 import com.rbmhtechnology.eventuate.sandbox.serializer.EventPayloadSerializer
+import com.rbmhtechnology.eventuate.sandbox.serializer.EventPayloadSerializer.decode
 
 import scala.reflect.ClassTag
 import scala.reflect._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
 trait EventCompatibility
-// TODO add DecodedEvent to each EncodedEvent
-// TODO add ExceptionOnDecode
-case class Compatible(event: EncodedEvent) extends EventCompatibility
-case class MinorIncompatibility(event: EncodedEvent, required: EventVersion, supported: EventVersion) extends EventCompatibility
+case class Compatible(event: FullEvent) extends EventCompatibility
+case class MinorIncompatibility(event: FullEvent, required: EventVersion, supported: EventVersion) extends EventCompatibility
 case class MajorIncompatibility(schema: String, required: EventVersion, supported: EventVersion) extends EventCompatibility
+case class CannotDecode(serializer: Serializer, schema: String, cause: Throwable) extends EventCompatibility
 case class NoSerializer(serializerId: Int) extends EventCompatibility
-case class NotEventPayloadSerializer(event: EncodedEvent, serializer: Serializer) extends EventCompatibility
-case class NoEventVersion(event: EncodedEvent, serializerId: Int) extends EventCompatibility
+case class NotEventPayloadSerializer(event: FullEvent, serializer: Serializer) extends EventCompatibility
+case class NoEventVersion(event: FullEvent, serializerId: Int) extends EventCompatibility
 
 object EventCompatibility {
 
-  def eventCompatibility(event: EncodedEvent)(implicit serialization: Serialization): EventCompatibility = {
-    val serializerId = event.payload.serializerId
-    val manifest = event.payload.manifest
+  def eventCompatibility(encoded: EncodedEvent)(implicit serialization: Serialization): EventCompatibility = {
+    val serializerId = encoded.payload.serializerId
+    val manifest = encoded.payload.manifest
     val compatibility= for {
       serializer <- toRight(serialization.serializerByIdentity.get(serializerId), NoSerializer(serializerId))
+      event <- toRight(decode(encoded).map(FullEvent(encoded, _)), CannotDecode(serializer, manifest.schema, _ : Throwable))
       payloadSerializer <- castOrLeft[EventPayloadSerializer, EventCompatibility](serializer, NotEventPayloadSerializer(event, serializer))
       eventVersion <- toRight(manifest.eventVersion, NoEventVersion(event, serializerId))
       _ <- Left(compareVersions(event, payloadSerializer.eventVersion(manifest.schema), eventVersion)).right
@@ -31,8 +35,8 @@ object EventCompatibility {
     compatibility.left.get
   }
 
-  private def compareVersions(event: EncodedEvent, supported: EventVersion, required: EventVersion): EventCompatibility = {
-    if(supported.majorVersion < required.majorVersion) MajorIncompatibility(event.payload.manifest.schema, required, supported)
+  private def compareVersions(event: FullEvent, supported: EventVersion, required: EventVersion): EventCompatibility = {
+    if(supported.majorVersion < required.majorVersion) MajorIncompatibility(event.encoded.payload.manifest.schema, required, supported)
     else if(supported.majorVersion == required.majorVersion && supported.minorVersion < required.minorVersion) MinorIncompatibility(event, required, supported)
     else Compatible(event)
   }
@@ -42,4 +46,10 @@ object EventCompatibility {
 
   private def toRight[L, R](option: Option[R], left: L): Either.RightProjection[L, R] =
     Either.cond(option.isDefined, option.get, left).right
+
+  private def toRight[L, R](t: Try[R], makeLeft: Throwable => L): Either.RightProjection[L, R] =
+    t match {
+      case Success(r) => Right(r).right
+      case Failure(ex) => Left(makeLeft(ex)).right
+    }
 }

--- a/src/main/scala/com/rbmhtechnology/eventuate/sandbox/EventCompatibility.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/sandbox/EventCompatibility.scala
@@ -1,0 +1,45 @@
+package com.rbmhtechnology.eventuate.sandbox
+
+import akka.serialization.Serialization
+import akka.serialization.Serializer
+import com.rbmhtechnology.eventuate.sandbox.serializer.EventPayloadSerializer
+
+import scala.reflect.ClassTag
+import scala.reflect._
+
+trait EventCompatibility
+// TODO add DecodedEvent to each EncodedEvent
+// TODO add ExceptionOnDecode
+case class Compatible(event: EncodedEvent) extends EventCompatibility
+case class MinorIncompatibility(event: EncodedEvent, required: EventVersion, supported: EventVersion) extends EventCompatibility
+case class MajorIncompatibility(schema: String, required: EventVersion, supported: EventVersion) extends EventCompatibility
+case class NoSerializer(serializerId: Int) extends EventCompatibility
+case class NotEventPayloadSerializer(event: EncodedEvent, serializer: Serializer) extends EventCompatibility
+case class NoEventVersion(event: EncodedEvent, serializerId: Int) extends EventCompatibility
+
+object EventCompatibility {
+
+  def eventCompatibility(event: EncodedEvent)(implicit serialization: Serialization): EventCompatibility = {
+    val serializerId = event.payload.serializerId
+    val manifest = event.payload.manifest
+    val compatibility= for {
+      serializer <- toRight(serialization.serializerByIdentity.get(serializerId), NoSerializer(serializerId))
+      payloadSerializer <- castOrLeft[EventPayloadSerializer, EventCompatibility](serializer, NotEventPayloadSerializer(event, serializer))
+      eventVersion <- toRight(manifest.eventVersion, NoEventVersion(event, serializerId))
+      _ <- Left(compareVersions(event, payloadSerializer.eventVersion(manifest.schema), eventVersion)).right
+    } yield ()
+    compatibility.left.get
+  }
+
+  private def compareVersions(event: EncodedEvent, supported: EventVersion, required: EventVersion): EventCompatibility = {
+    if(supported.majorVersion < required.majorVersion) MajorIncompatibility(event.payload.manifest.schema, required, supported)
+    else if(supported.majorVersion == required.majorVersion && supported.minorVersion < required.minorVersion) MinorIncompatibility(event, required, supported)
+    else Compatible(event)
+  }
+
+  private def castOrLeft[A : ClassTag, L](a: AnyRef, left: L): Either.RightProjection[L, A] =
+    Either.cond(classTag[A].runtimeClass.isAssignableFrom(a.getClass), a.asInstanceOf[A], left).right
+
+  private def toRight[L, R](option: Option[R], left: L): Either.RightProjection[L, R] =
+    Either.cond(option.isDefined, option.get, left).right
+}

--- a/src/main/scala/com/rbmhtechnology/eventuate/sandbox/EventReplicationDecider.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/sandbox/EventReplicationDecider.scala
@@ -1,0 +1,45 @@
+package com.rbmhtechnology.eventuate.sandbox
+
+import com.rbmhtechnology.eventuate.sandbox.EventReplicationDecider.ReplicationDecision
+
+// TODO find better names
+trait EventReplicationDecider {
+  def decide(sourceLogId: String)(eventCompatibility: EventCompatibility): ReplicationDecision
+}
+
+object EventReplicationDecider {
+
+  trait ReplicationDecision
+  // TODO add DecodedEvent
+  case class Keep(event: EncodedEvent) extends ReplicationDecision
+  case class Stop(reason: EventCompatibility) extends ReplicationDecision
+  case object Filter extends ReplicationDecision
+
+  object ReplicationDecision {
+    def unwrapKeep(decision: ReplicationDecision): EncodedEvent = decision match {
+      case Keep(event) => event
+    }
+    def replicationContinues(decision: ReplicationDecision): Boolean =
+      !decision.isInstanceOf[Stop]
+  }
+
+  object StopOnIncompatibility extends EventReplicationDecider {
+    override def decide(sourceLogId: String)(eventCompatibility: EventCompatibility): ReplicationDecision =
+      eventCompatibility match {
+        case Compatible(event) => Keep(event)
+        case _ => Stop(eventCompatibility)
+      }
+  }
+
+  object StopOnUnserializableKeepOthers extends EventReplicationDecider {
+    override def decide(sourceLogId: String)(eventCompatibility: EventCompatibility): ReplicationDecision =
+      eventCompatibility match {
+        case Compatible(event) => Keep(event)
+        case MinorIncompatibility(event, _, _) => Keep(event)
+        case NoEventVersion(event, _) => Keep(event)
+        case NotEventPayloadSerializer(event, _) => Keep(event)
+        case _ => Stop(eventCompatibility)
+      }
+  }
+}
+

--- a/src/main/scala/com/rbmhtechnology/eventuate/sandbox/EventReplicationDecider.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/sandbox/EventReplicationDecider.scala
@@ -10,13 +10,12 @@ trait EventReplicationDecider {
 object EventReplicationDecider {
 
   trait ReplicationDecision
-  // TODO add DecodedEvent
-  case class Keep(event: EncodedEvent) extends ReplicationDecision
+  case class Keep(event: FullEvent) extends ReplicationDecision
   case class Stop(reason: EventCompatibility) extends ReplicationDecision
   case object Filter extends ReplicationDecision
 
   object ReplicationDecision {
-    def unwrapKeep(decision: ReplicationDecision): EncodedEvent = decision match {
+    def unwrapKeep(decision: ReplicationDecision): FullEvent = decision match {
       case Keep(event) => event
     }
     def replicationContinues(decision: ReplicationDecision): Boolean =

--- a/src/main/scala/com/rbmhtechnology/eventuate/sandbox/EventReplicationDecider.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/sandbox/EventReplicationDecider.scala
@@ -4,7 +4,7 @@ import com.rbmhtechnology.eventuate.sandbox.EventReplicationDecider.ReplicationD
 
 // TODO find better names
 trait EventReplicationDecider {
-  def decide(sourceLogId: String)(eventCompatibility: EventCompatibility): ReplicationDecision
+  def decide(eventCompatibility: EventCompatibility): ReplicationDecision
 }
 
 object EventReplicationDecider {
@@ -23,7 +23,7 @@ object EventReplicationDecider {
   }
 
   object StopOnIncompatibility extends EventReplicationDecider {
-    override def decide(sourceLogId: String)(eventCompatibility: EventCompatibility): ReplicationDecision =
+    override def decide(eventCompatibility: EventCompatibility): ReplicationDecision =
       eventCompatibility match {
         case Compatible(event) => Keep(event)
         case _ => Stop(eventCompatibility)
@@ -31,7 +31,7 @@ object EventReplicationDecider {
   }
 
   object StopOnUnserializableKeepOthers extends EventReplicationDecider {
-    override def decide(sourceLogId: String)(eventCompatibility: EventCompatibility): ReplicationDecision =
+    override def decide(eventCompatibility: EventCompatibility): ReplicationDecision =
       eventCompatibility match {
         case Compatible(event) => Keep(event)
         case MinorIncompatibility(event, _, _) => Keep(event)

--- a/src/main/scala/com/rbmhtechnology/eventuate/sandbox/ReplicationProtocol.scala
+++ b/src/main/scala/com/rbmhtechnology/eventuate/sandbox/ReplicationProtocol.scala
@@ -16,4 +16,5 @@ object ReplicationProtocol {
 
   case class ReplicationWrite(events: Seq[EncodedEvent], sourceLogId: String, progress: Long)
   case class ReplicationWriteSuccess(events: Seq[EncodedEvent], sourceLogId: String, progress: Long, targetVersionVector: VectorTime)
+  case class ReplicationWriteFailure(cause: Throwable)
 }

--- a/src/test/scala/com/rbmhtechnology/eventuate/sandbox/EventLogSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/sandbox/EventLogSpec.scala
@@ -52,7 +52,7 @@ class EventLogSpec extends TestKit(ActorSystem("test")) with WordSpecLike with M
   implicit val serialization: Serialization = SerializationExtension(system)
 
   override protected def beforeEach(): Unit =
-    log = system.actorOf(EventLog.props(LogId1, Map(LogId2 -> excludePayload("y")), excludePayload("z"), StopOnUnserializableKeepOthers))
+    log = system.actorOf(EventLog.props(LogId1, Map(LogId2 -> excludePayload("y")), excludePayload("z")))
 
   override protected def afterEach(): Unit =
     system.stop(log)

--- a/src/test/scala/com/rbmhtechnology/eventuate/sandbox/ReplicationEndpointSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/sandbox/ReplicationEndpointSpec.scala
@@ -4,10 +4,8 @@ import akka.actor._
 import akka.pattern.ask
 import akka.testkit._
 import akka.util.Timeout
-
 import com.rbmhtechnology.eventuate.sandbox.EventsourcingProtocol._
 import com.rbmhtechnology.eventuate.sandbox.ReplicationEndpoint._
-
 import org.scalatest._
 
 object ReplicationEndpointSpec {

--- a/src/test/scala/com/rbmhtechnology/eventuate/sandbox/SchemaEvolutionSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/eventuate/sandbox/SchemaEvolutionSpec.scala
@@ -1,0 +1,166 @@
+package com.rbmhtechnology.eventuate.sandbox
+
+import akka.actor.ActorRef
+import akka.actor.ExtendedActorSystem
+import akka.testkit.TestProbe
+import akka.util.Timeout
+import com.rbmhtechnology.eventuate.sandbox.EventReplicationDecider.ReplicationDecision
+import com.rbmhtechnology.eventuate.sandbox.EventReplicationDecider.Filter
+import com.rbmhtechnology.eventuate.sandbox.EventReplicationDecider.Keep
+import com.rbmhtechnology.eventuate.sandbox.EventReplicationDecider.Stop
+import com.rbmhtechnology.eventuate.sandbox.EventsourcingProtocol.Subscribe
+import com.rbmhtechnology.eventuate.sandbox.EventsourcingProtocol.Write
+import com.rbmhtechnology.eventuate.sandbox.serializer.EventPayloadSerializer
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+import scala.concurrent.duration.DurationInt
+
+object SchemaEvolutionSpec {
+  val EmitterId1 = "EM1"
+  val EmitterId2 = "EM2"
+  val EndpointId1 = "EP1"
+  val EndpointId2 = "EP2"
+
+  val LogName = "L"
+
+  def serializerConfig(serializerClass: Class[_]) =
+    ConfigFactory.parseString(
+      s"""
+        |akka.actor {
+        |  serializers {
+        |    test-event = "${serializerClass.getName}"
+        |  }
+        |  serialization-bindings {
+        |    "${classOf[Format].getName}" = test-event
+        |  }
+        |}
+      """.stripMargin)
+
+  trait Format extends Serializable
+  case object CompatibleEvent extends Format
+  case object MinorIncompatibleEvent extends Format
+  case object MajorIncompatibleEvent extends Format
+  case object NoVersionEvent
+
+
+  abstract class TestSerializer extends EventPayloadSerializer {
+    protected val CompatibleEventManifest = CompatibleEvent.toString
+    protected val MinorIncompatibleEventManifest = MinorIncompatibleEvent.toString
+    protected val MajorIncompatibleEventManifest = MajorIncompatibleEvent.toString
+
+    override def identifier: Int = 896798
+
+    override def manifest(o: AnyRef): String =
+      o.toString
+
+    override def toBinary(o: AnyRef): Array[Byte] =
+      Array.empty[Byte]
+
+    override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef =
+      manifest match {
+        case CompatibleEventManifest => CompatibleEvent
+        case MinorIncompatibleEventManifest => MinorIncompatibleEvent
+        case MajorIncompatibleEventManifest => MajorIncompatibleEvent
+      }
+  }
+
+  case class TestSerializer1(system: ExtendedActorSystem) extends TestSerializer {
+    override def eventVersion(schema: String): EventVersion =
+      schema match {
+        case CompatibleEventManifest => EventVersion(1,1)
+        case MinorIncompatibleEventManifest => EventVersion(1,2)
+        case MajorIncompatibleEventManifest => EventVersion(2,1)
+      }
+  }
+
+  case class TestSerializer2(system: ExtendedActorSystem) extends TestSerializer {
+    override def eventVersion(schema: String) =
+      EventVersion(1,1)
+  }
+
+  val stopOnUnexpectedFilterMajorContinueOnMinor =
+    new EventReplicationDecider {
+      override def decide(sourceLogId: String)(eventCompatibility: EventCompatibility): ReplicationDecision =
+        eventCompatibility match {
+          case Compatible(event) => Keep(event)
+          case MinorIncompatibility(event, _, _) => Keep(event)
+          case MajorIncompatibility(_, _, _) => Filter
+          case _ => Stop(eventCompatibility)
+        }
+    }
+
+  def payloadEquals(payload: AnyRef): PartialFunction[Any, Any] = {
+    case DecodedEvent(_, actual) if actual == payload => actual
+  }
+}
+
+class SchemaEvolutionSpec extends WordSpec with Matchers with BeforeAndAfterEach {
+
+  import SchemaEvolutionSpec._
+
+  private var endpoint1: ReplicationEndpoint = _
+  private var endpoint2: ReplicationEndpoint = _
+  private var probe1: TestProbe = _
+  private var probe2: TestProbe = _
+  private var log1: ActorRef = _
+  private var log2: ActorRef = _
+
+  override protected def beforeEach(): Unit = {
+    endpoint1 = new ReplicationEndpoint(EndpointId1, Set(LogName), Map(), Map(), stopOnUnexpectedFilterMajorContinueOnMinor, serializerConfig(classOf[TestSerializer1]))
+    endpoint2 = new ReplicationEndpoint(EndpointId2, Set(LogName), Map(), Map(), stopOnUnexpectedFilterMajorContinueOnMinor, serializerConfig(classOf[TestSerializer2]))
+
+    probe1 = TestProbe()(endpoint1.system)
+    probe2 = TestProbe()(endpoint2.system)
+
+    log1 = endpoint1.eventLogs(LogName)
+    log2 = endpoint2.eventLogs(LogName)
+    log1 ! Subscribe(probe1.ref)
+    log2 ! Subscribe(probe2.ref)
+
+    endpoint1.connect(endpoint2)
+    endpoint2.connect(endpoint1)
+  }
+
+  override protected def afterEach(): Unit = {
+    endpoint1.terminate()
+    endpoint2.terminate()
+  }
+
+  "ReplicationEndpoint" must {
+    "replicate event from new to old location based on event compatibility" in {
+      log1 ! Write(List(DecodedEvent(EmitterId1, MajorIncompatibleEvent)))
+      // filtered
+
+      log1 ! Write(List(DecodedEvent(EmitterId1, CompatibleEvent)))
+      probe2.expectMsgPF(hint = CompatibleEvent.toString)(payloadEquals(CompatibleEvent))
+
+      log1 ! Write(List(DecodedEvent(EmitterId1, MinorIncompatibleEvent)))
+      probe2.expectMsgPF(hint = MinorIncompatibleEvent.toString)(payloadEquals(MinorIncompatibleEvent))
+
+      log1 ! Write(List(DecodedEvent(EmitterId1, NoVersionEvent)))
+      // Stopped
+
+      log1 ! Write(List(DecodedEvent(EmitterId1, CompatibleEvent)))
+      probe2.expectNoMsg(500.millis) // Still stopped
+    }
+    "replicate event from old to new location based on event compatibility" in {
+      log2 ! Write(List(DecodedEvent(EmitterId2, MajorIncompatibleEvent)))
+      probe1.expectMsgPF(hint = MajorIncompatibleEvent.toString)(payloadEquals(MajorIncompatibleEvent))
+
+      log2 ! Write(List(DecodedEvent(EmitterId2, CompatibleEvent)))
+      probe1.expectMsgPF(hint = CompatibleEvent.toString)(payloadEquals(CompatibleEvent))
+
+      log2 ! Write(List(DecodedEvent(EmitterId2, MinorIncompatibleEvent)))
+      probe1.expectMsgPF(hint = MinorIncompatibleEvent.toString)(payloadEquals(MinorIncompatibleEvent))
+
+      log2 ! Write(List(DecodedEvent(EmitterId2, NoVersionEvent)))
+      // Stopped
+
+      log2 ! Write(List(DecodedEvent(EmitterId2, CompatibleEvent)))
+      probe1.expectNoMsg(500.millis) // Still stopped
+    }
+  }
+}


### PR DESCRIPTION
missing:
- change deciders at runtime
- react on decode exceptions
- pass decoded events to replicationWrite for efficiency